### PR TITLE
Fix: Handle undefined values for color  and scale in tooltip rendering

### DIFF
--- a/components/ui/ColorButton.js
+++ b/components/ui/ColorButton.js
@@ -43,16 +43,11 @@ const CopyButton = ({ item, color, copyValue, backgroundColor }) => {
       </TooltipTrigger>
       <TooltipContent>
         <div className="space-y-0.5">
-          <div
-            className={
-              `text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg ` +
-              (copyValue === `${color}-${item.scale}`
-                ? "bg-zinc-800 text-zinc-100"
-                : "text-zinc-400")
-            }
-          >
-            <code>{`${color}-${item.scale}`}</code>
-          </div>
+          {item.scale && copyValue === `${color}-${item.scale}` && (
+            <div className="text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg bg-zinc-800 text-zinc-100">
+              <code>{`${color}-${item.scale}`}</code>
+            </div>
+          )}
           <div
             className={
               `text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg ` +

--- a/components/ui/ColorButton.js
+++ b/components/ui/ColorButton.js
@@ -43,9 +43,28 @@ const CopyButton = ({ item, color, copyValue, backgroundColor }) => {
       </TooltipTrigger>
       <TooltipContent>
         <div className="space-y-0.5">
-          {item.scale && copyValue === `${color}-${item.scale}` && (
-            <div className="text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg bg-zinc-800 text-zinc-100">
+          {item.scale && (
+            <div
+              className={
+                `text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg ` +
+                (copyValue === `${color}-${item.scale}`
+                  ? "bg-zinc-800 text-zinc-100"
+                  : "text-zinc-400")
+              }
+            >
               <code>{`${color}-${item.scale}`}</code>
+            </div>
+          )}
+          {item.className && (
+            <div
+              className={
+                `text-sm truncate w-full px-1.5 py-0.5 font-medium rounded-lg ` +
+                (copyValue === item.className
+                  ? "bg-zinc-800 text-zinc-100"
+                  : "text-zinc-400")
+              }
+            >
+              <code>{item.className}</code>
             </div>
           )}
           <div
@@ -98,7 +117,7 @@ export function ColorButtonTailwind({ item, color }) {
   const { format } = useColors();
   const copyValue = useMemo(
     () => (format === "className" ? `${color}-${item.scale}` : item[format]),
-    [format, color, item]
+    [format, color, item],
   );
 
   return (


### PR DESCRIPTION
This **PR** fixes an issue with tooltip rendering where undefined values for color and scale were causing rendering problems.

Changes Made: Added conditional checks for color and scale to handle undefined values. Ensured proper tooltip rendering for datasets with missing color or scale.



![Screenshot 2025-01-15 165246](https://github.com/user-attachments/assets/b93941fc-05e5-45e5-b003-575f45f45e2d)

<br/>
Tooltips now render correctly even when color or scale is missing.